### PR TITLE
Support JavaDoc tags

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,30 @@
             </goals>
             <configuration>
               <quiet>true</quiet>
+              <tags>
+                <tag>
+                  <name>apiNote</name>
+                  <placement>a</placement>
+                  <head>API Note:</head>
+                </tag>
+                <tag>
+                  <name>implSpec</name>
+                  <placement>a</placement>
+                  <head>Implementation Requirements:</head>
+                </tag>
+                <tag>
+                  <name>implNote</name>
+                  <placement>a</placement>
+                  <head>Implementation Note:</head>
+                </tag>
+                <tag><name>param</name></tag>
+                <tag><name>return</name></tag>
+                <tag><name>throws</name></tag>
+                <tag><name>since</name></tag>
+                <tag><name>version</name></tag>
+                <tag><name>serialData</name></tag>
+                <tag><name>see</name></tag>
+              </tags>
             </configuration>
           </execution>
           <execution>


### PR DESCRIPTION
The build shouldn't fail anymore for new tags